### PR TITLE
Adds explicit autocomplete handlers for existing commands

### DIFF
--- a/src/main/java/playfriends/mc/plugin/Main.java
+++ b/src/main/java/playfriends/mc/plugin/Main.java
@@ -3,6 +3,7 @@ package playfriends.mc.plugin;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
@@ -35,11 +36,12 @@ import playfriends.mc.plugin.playerdata.PlayerDataManager;
 import playfriends.mc.plugin.playerdata.SavePlayerDataTask;
 
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Main entry point for the plugin. */
 @SuppressWarnings("unused")
-public class Main extends JavaPlugin {
+public class Main extends JavaPlugin implements TabCompleter {
     private static final String ONLY_PLAYERS_CAN_USE_THIS_COMMAND_MSG = ChatColor.RED + "Only players can use this command.";
 
     /** The player data manager, to manager the player. */
@@ -109,6 +111,41 @@ public class Main extends JavaPlugin {
         }
 
         playerDataManager.loadAll();
+    }
+
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        switch(command.getName()) {
+            // These commands have no arguments
+            case "chill":
+            case "thrill":
+            case "zzz":
+            case "afktoggle":
+            case "keepxp":
+            case "perf":
+            case "list":
+                return List.of();
+
+            // These commands have arguments, but they are not autocompletable
+            // Syntax hints are not available via this API, for that the commands would have to be registered through Brigadier API
+            case "pronouns":
+            case "discord":
+                return List.of();
+
+            // Optionally could filter to only those options that match what the user has typed so far
+            // but i don't think there's any value gained from filtering a list of four options
+            case "keepinventory":
+                List<String> options = new ArrayList<>();
+                for (KeepInventoryRule value : KeepInventoryRule.values()) {
+                    options.add(value.name().toLowerCase());
+                }
+                return options;
+
+            // all other commands should fall back to the default executor
+            default:
+                return null;
+        }
     }
 
     @Override

--- a/src/main/java/playfriends/mc/plugin/Main.java
+++ b/src/main/java/playfriends/mc/plugin/Main.java
@@ -224,16 +224,7 @@ public class Main extends JavaPlugin implements TabCompleter {
                 }
             }
             case "list" -> {
-                if (sender instanceof Player player) {
-                    pluginManager.callEvent(new ListPlayersEvent(player));
-                } else {
-                    final List<? extends Player> sortedPlayers = new ArrayList<>(this.getServer().getOnlinePlayers());
-                    sortedPlayers.sort(Comparator.comparing(Player::getDisplayName));
-                    sender.sendMessage("Players online: " + sortedPlayers.size() + "/" + this.getServer().getMaxPlayers());
-                    for (Player player : sortedPlayers) {
-                        sender.sendMessage(" * " + player.getName());
-                    }
-                }
+                pluginManager.callEvent(new ListPlayersEvent(sender));
             }
             default     -> {
                 sender.sendMessage(ChatColor.RED + "I don't know a command named " + command.getName() + "!");

--- a/src/main/java/playfriends/mc/plugin/Main.java
+++ b/src/main/java/playfriends/mc/plugin/Main.java
@@ -37,6 +37,7 @@ import playfriends.mc.plugin.playerdata.SavePlayerDataTask;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 /** Main entry point for the plugin. */
@@ -226,7 +227,12 @@ public class Main extends JavaPlugin implements TabCompleter {
                 if (sender instanceof Player player) {
                     pluginManager.callEvent(new ListPlayersEvent(player));
                 } else {
-                    sender.sendMessage("Only players can use this command.");
+                    final List<? extends Player> sortedPlayers = new ArrayList<>(this.getServer().getOnlinePlayers());
+                    sortedPlayers.sort(Comparator.comparing(Player::getDisplayName));
+                    sender.sendMessage("Players online: " + sortedPlayers.size() + "/" + this.getServer().getMaxPlayers());
+                    for (Player player : sortedPlayers) {
+                        sender.sendMessage(" * " + player.getName());
+                    }
                 }
             }
             default     -> {

--- a/src/main/java/playfriends/mc/plugin/features/playerprofile/ListPlayersEvent.java
+++ b/src/main/java/playfriends/mc/plugin/features/playerprofile/ListPlayersEvent.java
@@ -1,14 +1,19 @@
 package playfriends.mc.plugin.features.playerprofile;
 
-import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import playfriends.mc.plugin.api.PlayerEvent;
 
-public class ListPlayersEvent extends PlayerEvent {
+public class ListPlayersEvent extends Event {
     private static final HandlerList HANDLERS_LIST = new HandlerList();
+    private final CommandSender sender;
 
-    public ListPlayersEvent(Player player) {
-        super(player);
+    public CommandSender getSender() {
+        return sender;
+    }
+
+    public ListPlayersEvent(CommandSender sender) {
+        this.sender = sender;
     }
 
     @Override

--- a/src/main/java/playfriends/mc/plugin/features/playerprofile/PlayerProfileHandler.java
+++ b/src/main/java/playfriends/mc/plugin/features/playerprofile/PlayerProfileHandler.java
@@ -2,6 +2,7 @@ package playfriends.mc.plugin.features.playerprofile;
 
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -117,7 +118,7 @@ public class PlayerProfileHandler implements ConfigAwareListener {
 
     @EventHandler
     public void onListCommand(ListPlayersEvent event) {
-        final Player sender = event.getPlayer();
+        final CommandSender sender = event.getSender();
 
         // Get a list of players sorted by their display names
         final List<? extends Player> sortedPlayers = new ArrayList<>(plugin.getServer().getOnlinePlayers());


### PR DESCRIPTION
**Currently**, all custom commands suggest player names as their second argument

**With this fix**, the majority of commands that don't take arguments will no longer suggest player names as autocomplete

Same for `/pronouns` and `/discord` because there's no preset options for those
:question: do we want to offer "common" pronoun options or would that be insensitive?
![image](https://user-images.githubusercontent.com/8430090/186761045-d5d26453-be54-470b-ba4b-baf37e1147e7.png)

and /keepinventory will provide all the valid argument names (lowercased)
![image](https://user-images.githubusercontent.com/8430090/186760673-5927079e-aaa1-493f-bcdc-828551ac3abf.png)
